### PR TITLE
Add windows support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,8 @@ rustflags = ["-C", "link-arg=-Wl,-undefined,dynamic_lookup"]
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld"
 
+[target.x86_64-pc-windows-gnu]
+linker = "rust-lld"
+
 [target.i686-pc-windows-msvc]
 linker = "rust-lld"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,4 +1,4 @@
-name: 'setup ext-wasm envrionment'
+name: 'setup ext-wasm environment'
 
 inputs:
   os:
@@ -30,13 +30,22 @@ runs:
 #          php --ini
 #          php-config          
 
-      - name: "installing Rust"
+      - name: "installing Stable Rust toolchain for Linux and Mac"
         uses: actions-rs/toolchain@v1
+        if: "!contains(matrix.os, 'windows')"
         with:
           toolchain: ${{ inputs.rust }}
           override: true
           components: rustfmt, clippy
-      
+
+      - name: "installing Nightly Rust toolchain for Windows"
+        uses: actions-rs/toolchain@v1
+        if: "contains(matrix.os, 'windows')"
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
       # LLVM & Clang
       - name: Cache LLVM and Clang
         id: cache-llvm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(windows, feature(abi_vectorcall))]
+
 mod types;
 
 use ext_php_rs::prelude::*;


### PR DESCRIPTION
fixes #3

Windows requires rust's nightly builds as documented:

- https://davidcole1340.github.io/ext-php-rs/getting-started/hello_world.html#cargoconfigtoml
- https://github.com/davidcole1340/ext-php-rs#windows-requirements

