### PR TITLE
Introduce function reference value types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cargo-php = "0.1.7"
-ext-php-rs = "0.10.1"
+ext-php-rs = {version = "0.10.1", features = ["closure"] }
 wasmer = { version = "4.1.0", default-features = true, features = ["sys"] }
 wasmer-compiler = "4.1.0"
 

--- a/ext-wasm.stubs.php
+++ b/ext-wasm.stubs.php
@@ -16,7 +16,7 @@ namespace Wasm {
     class InstanceBuilder {
         public static function fromWat(string $wat): \Wasm\InstanceBuilder {}
 
-        public function import(array $imports): void {}
+        public function import(Imports $imports): void {}
 
         public function build(): \Wasm\WasmInstance {}
     }


### PR DESCRIPTION
See #5 

This PR introduces support for function reference value types.

For example:

```php
$builder = InstanceBuilder::fromWat(
    <<<'EOWAT'
    (module
        (import "env" "greet" (func $greet))
        (func
            call $greet
        )
        (start 1) ;; run the first function automatically
    )
    EOWAT
);

$imports = Imports::create();
$imports->define('env', 'greet', Type\Global::immutable(
    function () use ($result) {
        echo 'Hello!';
    }
));


$builder->import($imports);
$instance = $builder->build();
```

> Hello!